### PR TITLE
fix: set the right extension for clair db

### DIFF
--- a/roles/r_quay/tasks/database.yml
+++ b/roles/r_quay/tasks/database.yml
@@ -73,7 +73,7 @@
       db: "{{ clair_db_dbname }}"
       ssl_mode: "{{ clair_db_sslmode | default(omit) }}"
       ca_cert: "{{ clair_db_ca_file | default(omit) }}"
-      name: pg_trgm
+      name: uuid-ossp
       state: present
 
 


### PR DESCRIPTION
Hi,

Following the documentation (https://access.redhat.com/documentation/en-us/red_hat_quay/3.7/html-single/manage_red_hat_quay/index#clair-standalone), the clair database only needs the "uuid-ossp" postgresql extension.

Anyway, the role works because the clair db user has admin privileges and the clair application can add the extension itself.